### PR TITLE
Fix BaseURL lookup

### DIFF
--- a/magento1.go
+++ b/magento1.go
@@ -75,7 +75,7 @@ func (m1 *Magento1) BaseURLs(docroot string) ([]string, error) {
 		return nil, err
 	}
 
-	rows, err := db.Query(`select distinct value from core_config_data where path like 'web/%secure/base_url'`)
+	rows, err := db.Query(`select distinct value from ` + cfg.DB.Prefix + `core_config_data where path like 'web/%secure/base_url'`)
 	if err != nil {
 		return nil, err
 	}

--- a/magento2.go
+++ b/magento2.go
@@ -123,7 +123,7 @@ func (m2 *Magento2) getBaseURLsFromDatabase(cfgPath string) ([]string, error) {
 		return nil, err
 	}
 
-	rows, err := db.Query(`select distinct value from core_config_data where path like 'web/%secure/base_url'`)
+	rows, err := db.Query(`select distinct value from ` + cfg.DB.Prefix + `core_config_data where path like 'web/%secure/base_url'`)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The lookup would fail, if the database uses a custom prefix. This should fix that.