### PR TITLE
Add generic domain docroot under `$HOME`

### DIFF
--- a/fixture/discovery/sansecfile.store
+++ b/fixture/discovery/sansecfile.store
@@ -1,0 +1,1 @@
+henlo i am a file for some reason, not a directory, let's see if this doesn't confuse it

--- a/phpcfg/phpcfg_test.go
+++ b/phpcfg/phpcfg_test.go
@@ -1,8 +1,8 @@
 package phpcfg
 
 import (
-	"testing"
 	"github.com/google/go-cmp/cmp"
+	"testing"
 )
 
 func TestParseShortArray(t *testing.T) {

--- a/platform.go
+++ b/platform.go
@@ -3,8 +3,8 @@ package gocommerce
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"regexp"
+	"strings"
 )
 
 type (
@@ -156,7 +156,7 @@ func (c *DBConfig) DSN() string {
 func (c *DBConfig) SafePrefix() (string, error) {
 	// prefix can only contain alphanum and underscores
 	re := regexp.MustCompile(`[^a-zA-Z0-9_]`)
-    if len(c.Prefix) > 0 && re.MatchString(c.Prefix) {
+	if len(c.Prefix) > 0 && re.MatchString(c.Prefix) {
 		return "", fmt.Errorf("invalid database prefix: %s", c.Prefix)
 	}
 

--- a/store.go
+++ b/store.go
@@ -17,7 +17,7 @@ var commonDocRoots = []string{
 	"$HOME/master/Magento1Website",
 	"$HOME/current",
 	"$HOME/magento2",
-	"/app/$USER", // adobe commerce
+	"/app/$USER",                       // adobe commerce
 	"$HOME/var/$SITE_NAME/logs",
 	"/var/www/html",
 	"$HOME/html",                       // jetrails
@@ -27,12 +27,13 @@ var commonDocRoots = []string{
 	"/home/cloudpanel/htdocs/*/current",
 	"/home/cloudpanel/htdocs/*",
 	"/code",
-	"/domains/*/http", // sonassi
+	"/domains/*/http",                  // sonassi
 	"/srv/*",
 	"$HOME/domains/*/public_html",
 	"/var/www/*",
 	"/var/www/*/public_html",
-	"/vhosts/*/httpdocs", // plesk
+	"/vhosts/*/httpdocs",               // plesk
+	"$HOME/*.*/",                       // generic domain pattern
 }
 
 func (s *Store) ConfigPath() string {

--- a/store.go
+++ b/store.go
@@ -17,7 +17,7 @@ var commonDocRoots = []string{
 	"$HOME/master/Magento1Website",
 	"$HOME/current",
 	"$HOME/magento2",
-	"/app/$USER",                       // adobe commerce
+	"/app/$USER", // adobe commerce
 	"$HOME/var/$SITE_NAME/logs",
 	"/var/www/html",
 	"$HOME/html",                       // jetrails
@@ -27,13 +27,13 @@ var commonDocRoots = []string{
 	"/home/cloudpanel/htdocs/*/current",
 	"/home/cloudpanel/htdocs/*",
 	"/code",
-	"/domains/*/http",                  // sonassi
+	"/domains/*/http", // sonassi
 	"/srv/*",
 	"$HOME/domains/*/public_html",
 	"/var/www/*",
 	"/var/www/*/public_html",
-	"/vhosts/*/httpdocs",               // plesk
-	"$HOME/*.*/",                       // generic domain pattern
+	"/vhosts/*/httpdocs", // plesk
+	"$HOME/*.*",          // generic domain pattern
 }
 
 func (s *Store) ConfigPath() string {

--- a/store_test.go
+++ b/store_test.go
@@ -21,13 +21,16 @@ func TestDiscoverStores(t *testing.T) {
 	os.Setenv("HOME", fixtureBase+"/discovery")
 	stores := DiscoverStores()
 
-	assert.Len(t, stores, 2)
+	assert.Len(t, stores, 3)
 
 	assert.Equal(t, "Magento 2", stores[0].Platform.Name())
 	assert.Contains(t, stores[0].DocRoot, "discovery/public_html/current")
 
 	assert.Equal(t, "WooCommerce", stores[1].Platform.Name())
 	assert.Contains(t, stores[1].DocRoot, "discovery/applications/123456789/public_html")
+
+	assert.Equal(t, "Magento 2", stores[2].Platform.Name())
+	assert.Contains(t, stores[2].DocRoot, "discovery/sansec.store")
 }
 
 func TestDiscoverStoresEmpty(t *testing.T) {


### PR DESCRIPTION
Not sure if this is the right way to do it, but the idea is that it would match all folders in `$HOME` with format `domain.tld`

https://www.pivotaltracker.com/n/projects/2320827/stories/187053834