### PR TITLE
Make DB connection use `PingContext`

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,8 +1,10 @@
 package gocommerce
 
 import (
+	"context"
 	"database/sql"
 	"os"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -29,7 +31,10 @@ func ConnectDB(cfg DBConfig) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = db.Ping()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = db.PingContext(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/db.go
+++ b/db.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"os"
-	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -15,7 +14,7 @@ var defaultSockets = []string{
 }
 
 // NB copy StoreConfig, as we may modify it
-func ConnectDB(cfg DBConfig) (*sql.DB, error) {
+func ConnectDB(cfg DBConfig, ctx context.Context) (*sql.DB, error) {
 	// Mimic libmysql behavior, where "localhost" is overridden with
 	// system specific unix socket.
 	if cfg.Host == "localhost" || cfg.Host == "" {
@@ -32,8 +31,9 @@ func ConnectDB(cfg DBConfig) (*sql.DB, error) {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	err = db.PingContext(ctx)
 	if err != nil {
 		return nil, err

--- a/db.go
+++ b/db.go
@@ -14,7 +14,7 @@ var defaultSockets = []string{
 }
 
 // NB copy StoreConfig, as we may modify it
-func ConnectDB(cfg DBConfig, ctx context.Context) (*sql.DB, error) {
+func ConnectDB(ctx context.Context, cfg DBConfig) (*sql.DB, error) {
 	// Mimic libmysql behavior, where "localhost" is overridden with
 	// system specific unix socket.
 	if cfg.Host == "localhost" || cfg.Host == "" {

--- a/magento1.go
+++ b/magento1.go
@@ -1,6 +1,7 @@
 package gocommerce
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -62,7 +63,7 @@ func (m1 *Magento1) ParseConfig(cfgPath string) (*StoreConfig, error) {
 	}, nil
 }
 
-func (m1 *Magento1) BaseURLs(docroot string) ([]string, error) {
+func (m1 *Magento1) BaseURLs(docroot string, ctx context.Context) ([]string, error) {
 	cfgPath := filepath.Join(docroot, m1.ConfigPath())
 
 	cfg, err := m1.ParseConfig(cfgPath)
@@ -70,7 +71,7 @@ func (m1 *Magento1) BaseURLs(docroot string) ([]string, error) {
 		return nil, err
 	}
 
-	db, err := ConnectDB(*cfg.DB)
+	db, err := ConnectDB(*cfg.DB, ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/magento1.go
+++ b/magento1.go
@@ -63,7 +63,7 @@ func (m1 *Magento1) ParseConfig(cfgPath string) (*StoreConfig, error) {
 	}, nil
 }
 
-func (m1 *Magento1) BaseURLs(docroot string, ctx context.Context) ([]string, error) {
+func (m1 *Magento1) BaseURLs(ctx context.Context, docroot string) ([]string, error) {
 	cfgPath := filepath.Join(docroot, m1.ConfigPath())
 
 	cfg, err := m1.ParseConfig(cfgPath)
@@ -71,7 +71,7 @@ func (m1 *Magento1) BaseURLs(docroot string, ctx context.Context) ([]string, err
 		return nil, err
 	}
 
-	db, err := ConnectDB(*cfg.DB, ctx)
+	db, err := ConnectDB(ctx, *cfg.DB)
 	if err != nil {
 		return nil, err
 	}

--- a/magento1_integration_test.go
+++ b/magento1_integration_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetMagento1BaseURLsFromDatabase(t *testing.T) {
-	baseURLs, err := m1store.BaseURLs(fixtureBase + "magento1_integration")
+	baseURLs, err := m1store.BaseURLs(nil, fixtureBase+"magento1_integration")
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"https://app.magento1.test/", "https://second.magento1.test/"}, baseURLs)
 }

--- a/magento1_integration_test.go
+++ b/magento1_integration_test.go
@@ -4,12 +4,13 @@ package gocommerce
 
 import (
 	"testing"
+	"context"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetMagento1BaseURLsFromDatabase(t *testing.T) {
-	baseURLs, err := m1store.BaseURLs(nil, fixtureBase+"magento1_integration")
+	baseURLs, err := m1store.BaseURLs(context.TODO(), fixtureBase+"magento1_integration")
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"https://app.magento1.test/", "https://second.magento1.test/"}, baseURLs)
 }

--- a/magento2.go
+++ b/magento2.go
@@ -70,10 +70,10 @@ func (m2 *Magento2) ParseConfig(cfgPath string) (*StoreConfig, error) {
 	}, nil
 }
 
-func (m2 *Magento2) BaseURLs(docroot string, ctx context.Context) ([]string, error) {
+func (m2 *Magento2) BaseURLs(ctx context.Context, docroot string) ([]string, error) {
 	cfgPath := filepath.Join(docroot, m2.ConfigPath())
 	urls := []string{}
-	if ud, err := m2.getBaseURLsFromDatabase(cfgPath, ctx); err == nil {
+	if ud, err := m2.getBaseURLsFromDatabase(ctx, cfgPath); err == nil {
 		urls = append(urls, ud...)
 	}
 	if uc, err := m2.getBaseURLsFromConfig(cfgPath); err == nil {
@@ -121,13 +121,13 @@ func (m2 *Magento2) getBaseURLsFromConfig(cfgPath string) ([]string, error) {
 	return nil, errors.New("base url(s) not found in config")
 }
 
-func (m2 *Magento2) getBaseURLsFromDatabase(cfgPath string, ctx context.Context) ([]string, error) {
+func (m2 *Magento2) getBaseURLsFromDatabase(ctx context.Context, cfgPath string) ([]string, error) {
 	cfg, err := m2.ParseConfig(cfgPath)
 	if err != nil {
 		return nil, err
 	}
 
-	db, err := ConnectDB(*cfg.DB, ctx)
+	db, err := ConnectDB(ctx, *cfg.DB)
 	if err != nil {
 		return nil, err
 	}

--- a/magento2.go
+++ b/magento2.go
@@ -1,6 +1,7 @@
 package gocommerce
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -69,10 +70,10 @@ func (m2 *Magento2) ParseConfig(cfgPath string) (*StoreConfig, error) {
 	}, nil
 }
 
-func (m2 *Magento2) BaseURLs(docroot string) ([]string, error) {
+func (m2 *Magento2) BaseURLs(docroot string, ctx context.Context) ([]string, error) {
 	cfgPath := filepath.Join(docroot, m2.ConfigPath())
 	urls := []string{}
-	if ud, err := m2.getBaseURLsFromDatabase(cfgPath); err == nil {
+	if ud, err := m2.getBaseURLsFromDatabase(cfgPath, ctx); err == nil {
 		urls = append(urls, ud...)
 	}
 	if uc, err := m2.getBaseURLsFromConfig(cfgPath); err == nil {
@@ -120,13 +121,13 @@ func (m2 *Magento2) getBaseURLsFromConfig(cfgPath string) ([]string, error) {
 	return nil, errors.New("base url(s) not found in config")
 }
 
-func (m2 *Magento2) getBaseURLsFromDatabase(cfgPath string) ([]string, error) {
+func (m2 *Magento2) getBaseURLsFromDatabase(cfgPath string, ctx context.Context) ([]string, error) {
 	cfg, err := m2.ParseConfig(cfgPath)
 	if err != nil {
 		return nil, err
 	}
 
-	db, err := ConnectDB(*cfg.DB)
+	db, err := ConnectDB(*cfg.DB, ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/magento2_integration_test.go
+++ b/magento2_integration_test.go
@@ -4,12 +4,13 @@ package gocommerce
 
 import (
 	"testing"
+	"context"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetMagento2BaseURLsFromDatabase(t *testing.T) {
-	baseURLs, err := m2store.BaseURLs(nil, fixtureBase+"magento2_integration")
+	baseURLs, err := m2store.BaseURLs(context.TODO(), fixtureBase+"magento2_integration")
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"https://sansec.io/", "https://api.sansec.io/"}, baseURLs)
 }

--- a/magento2_integration_test.go
+++ b/magento2_integration_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetMagento2BaseURLsFromDatabase(t *testing.T) {
-	baseURLs, err := m2store.BaseURLs(fixtureBase + "magento2_integration")
+	baseURLs, err := m2store.BaseURLs(nil, fixtureBase + "magento2_integration")
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"https://sansec.io/", "https://api.sansec.io/"}, baseURLs)
 }

--- a/magento2_integration_test.go
+++ b/magento2_integration_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetMagento2BaseURLsFromDatabase(t *testing.T) {
-	baseURLs, err := m2store.BaseURLs(nil, fixtureBase + "magento2_integration")
+	baseURLs, err := m2store.BaseURLs(nil, fixtureBase+"magento2_integration")
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"https://sansec.io/", "https://api.sansec.io/"}, baseURLs)
 }

--- a/magento2_test.go
+++ b/magento2_test.go
@@ -63,7 +63,7 @@ func TestGetMagentoVersionWithoutSystemPackages(t *testing.T) {
 }
 
 func TestGetMagentoBaseURLsFromConfigNilCtx(t *testing.T) {
-	baseURLs, err := m2store.BaseURLs(nil, fixtureBase + "magento2")
+	baseURLs, err := m2store.BaseURLs(nil, fixtureBase+"magento2")
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"https://sansec.io/", "https://api.sansec.io/"}, baseURLs)
 }

--- a/magento2_test.go
+++ b/magento2_test.go
@@ -63,7 +63,7 @@ func TestGetMagentoVersionWithoutSystemPackages(t *testing.T) {
 }
 
 func TestGetMagentoBaseURLsFromConfigNilCtx(t *testing.T) {
-	baseURLs, err := m2store.BaseURLs(fixtureBase + "magento2", nil)
+	baseURLs, err := m2store.BaseURLs(nil, fixtureBase + "magento2")
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"https://sansec.io/", "https://api.sansec.io/"}, baseURLs)
 }

--- a/magento2_test.go
+++ b/magento2_test.go
@@ -1,6 +1,7 @@
 package gocommerce
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,7 @@ func TestGetMagentoVersionWithoutSystemPackages(t *testing.T) {
 }
 
 func TestGetMagentoBaseURLsFromConfigNilCtx(t *testing.T) {
-	baseURLs, err := m2store.BaseURLs(nil, fixtureBase+"magento2")
+	baseURLs, err := m2store.BaseURLs(context.TODO(), fixtureBase+"magento2")
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"https://sansec.io/", "https://api.sansec.io/"}, baseURLs)
 }

--- a/magento2_test.go
+++ b/magento2_test.go
@@ -62,8 +62,8 @@ func TestGetMagentoVersionWithoutSystemPackages(t *testing.T) {
 	assert.Equal(t, "2.4.2-p2", version)
 }
 
-func TestGetMagentoBaseURLsFromConfig(t *testing.T) {
-	baseURLs, err := m2store.BaseURLs(fixtureBase + "magento2")
+func TestGetMagentoBaseURLsFromConfigNilCtx(t *testing.T) {
+	baseURLs, err := m2store.BaseURLs(fixtureBase + "magento2", nil)
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"https://sansec.io/", "https://api.sansec.io/"}, baseURLs)
 }

--- a/opencart4.go
+++ b/opencart4.go
@@ -1,6 +1,7 @@
 package gocommerce
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -57,7 +58,7 @@ func (oc4 *OpenCart4) ParseConfig(cfgPath string) (*StoreConfig, error) {
 	}, nil
 }
 
-func (oc4 *OpenCart4) BaseURLs(docroot string) ([]string, error) {
+func (oc4 *OpenCart4) BaseURLs(docroot string, ctx context.Context) ([]string, error) {
 	cfgPath := filepath.Join(docroot, "config.php")
 	cfg, err := os.ReadFile(cfgPath)
 	if err != nil {

--- a/opencart4.go
+++ b/opencart4.go
@@ -58,7 +58,7 @@ func (oc4 *OpenCart4) ParseConfig(cfgPath string) (*StoreConfig, error) {
 	}, nil
 }
 
-func (oc4 *OpenCart4) BaseURLs(docroot string, ctx context.Context) ([]string, error) {
+func (oc4 *OpenCart4) BaseURLs(ctx context.Context, docroot string) ([]string, error) {
 	cfgPath := filepath.Join(docroot, "config.php")
 	cfg, err := os.ReadFile(cfgPath)
 	if err != nil {

--- a/opencart4_config_test.go
+++ b/opencart4_config_test.go
@@ -14,7 +14,7 @@ func TestOpenCartConfig(t *testing.T) {
 
 func TestOpenCartURL(t *testing.T) {
 	oc4 := OpenCart4{}
-	urls, err := oc4.BaseURLs(fixtureBase + "opencart4")
+	urls, err := oc4.BaseURLs(fixtureBase + "opencart4", nil)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, urls)
 	assert.Equal(t, "http://sansec.io/", urls[0])

--- a/opencart4_config_test.go
+++ b/opencart4_config_test.go
@@ -14,7 +14,7 @@ func TestOpenCartConfig(t *testing.T) {
 
 func TestOpenCartURL(t *testing.T) {
 	oc4 := OpenCart4{}
-	urls, err := oc4.BaseURLs(nil, fixtureBase + "opencart4")
+	urls, err := oc4.BaseURLs(nil, fixtureBase+"opencart4")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, urls)
 	assert.Equal(t, "http://sansec.io/", urls[0])

--- a/opencart4_config_test.go
+++ b/opencart4_config_test.go
@@ -1,6 +1,7 @@
 package gocommerce
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ func TestOpenCartConfig(t *testing.T) {
 
 func TestOpenCartURL(t *testing.T) {
 	oc4 := OpenCart4{}
-	urls, err := oc4.BaseURLs(nil, fixtureBase+"opencart4")
+	urls, err := oc4.BaseURLs(context.TODO(), fixtureBase+"opencart4")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, urls)
 	assert.Equal(t, "http://sansec.io/", urls[0])

--- a/opencart4_config_test.go
+++ b/opencart4_config_test.go
@@ -14,7 +14,7 @@ func TestOpenCartConfig(t *testing.T) {
 
 func TestOpenCartURL(t *testing.T) {
 	oc4 := OpenCart4{}
-	urls, err := oc4.BaseURLs(fixtureBase + "opencart4", nil)
+	urls, err := oc4.BaseURLs(nil, fixtureBase + "opencart4")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, urls)
 	assert.Equal(t, "http://sansec.io/", urls[0])

--- a/phpcfg/phpcfg_test.go
+++ b/phpcfg/phpcfg_test.go
@@ -1,8 +1,9 @@
 package phpcfg
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseShortArray(t *testing.T) {

--- a/platform.go
+++ b/platform.go
@@ -1,6 +1,7 @@
 package gocommerce
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -38,7 +39,7 @@ type (
 		Name() string
 		ParseConfig(cfgPath string) (*StoreConfig, error)
 		Version(docroot string) (string, error)
-		BaseURLs(docroot string) ([]string, error)
+		BaseURLs(docroot string, ctx context.Context) ([]string, error)
 		ConfigPath() string
 		UniquePath() string
 	}
@@ -121,7 +122,7 @@ func (b *basePlatform) ParseConfig(cfgPath string) (*StoreConfig, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (b *basePlatform) BaseURLs(docroot string) ([]string, error) {
+func (b *basePlatform) BaseURLs(docroot string, ctx context.Context) ([]string, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/platform.go
+++ b/platform.go
@@ -39,7 +39,7 @@ type (
 		Name() string
 		ParseConfig(cfgPath string) (*StoreConfig, error)
 		Version(docroot string) (string, error)
-		BaseURLs(docroot string, ctx context.Context) ([]string, error)
+		BaseURLs(ctx context.Context, docroot string) ([]string, error)
 		ConfigPath() string
 		UniquePath() string
 	}
@@ -122,7 +122,7 @@ func (b *basePlatform) ParseConfig(cfgPath string) (*StoreConfig, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (b *basePlatform) BaseURLs(docroot string, ctx context.Context) ([]string, error) {
+func (b *basePlatform) BaseURLs(ctx context.Context, docroot string) ([]string, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/store.go
+++ b/store.go
@@ -34,11 +34,11 @@ var commonDocRoots = []string{
 	"/var/www/*",
 	"/var/www/*/public_html",
 	"/var/www/vhosts/*/htdocs",
-	"/vhosts/*/httpdocs",         // plesk
-	"$HOME/public_html/..",       // nexcess
-	"$HOME/public/..",            // hypernode
-	"$HOME/public",               // hypernode, nimbus hosting
-	"$HOME/??*.*",                // generic domain pattern
+	"/vhosts/*/httpdocs",   // plesk
+	"$HOME/public_html/..", // nexcess
+	"$HOME/public/..",      // hypernode
+	"$HOME/public",         // hypernode, nimbus hosting
+	"$HOME/??*.*",          // generic domain pattern
 }
 
 func (s *Store) ConfigPath() string {

--- a/tests.go
+++ b/tests.go
@@ -7,7 +7,7 @@ import (
 
 const fixtureBase = "fixture/"
 
-func dbConfigFromSource(t *testing.T, src string, pl PlatformInterface) *DBConfig {
+func dbConfigFromSource(_ *testing.T, src string, pl PlatformInterface) *DBConfig {
 	cfg, e := pl.ParseConfig(src)
 	if e != nil {
 		fmt.Println(e)


### PR DESCRIPTION
Assists https://github.com/sansecio/ecomscan/pull/164 (prevents timeout to database)

...or perhaps alternatively, we could make it so that we can pass the existing connection from eComscan, if it exists?