### PR TITLE
Fix double-quoted strings in PHP config parser

### DIFF
--- a/phpcfg/phpcfg.go
+++ b/phpcfg/phpcfg.go
@@ -39,9 +39,9 @@ func getReturnedArray(ret *stmt.Return) node.Node {
 	return nil
 }
 
-// Removes single quotes if present.
+// Removes surrounding quotes (single or double) if present.
 func unquote(s string) string {
-	if s[0] == '\'' && s[len(s)-1] == '\'' {
+	if len(s) >= 2 && (s[0] == '\'' || s[0] == '"') && s[len(s)-1] == s[0] {
 		return s[1 : len(s)-1]
 	}
 	return s

--- a/phpcfg/phpcfg_test.go
+++ b/phpcfg/phpcfg_test.go
@@ -45,6 +45,43 @@ return [
 	}
 }
 
+func TestParseDoubleQuotedStrings(t *testing.T) {
+	src := `
+<?php
+return [
+    "db" => [
+        "table_prefix" => "",
+        "connection" => [
+            "default" => [
+                "host" => "localhost",
+                "dbname" => "somename123_db",
+                "password" => "aabbccddeeff",
+                "active" => "1",
+                "driver_options" => [
+                    1014 => FALSE
+                ]
+            ]
+        ]
+    ]
+];`
+
+	expected := map[string]string{
+		"root.db.table_prefix":                                "",
+		"root.db.connection.default.host":                     "localhost",
+		"root.db.connection.default.dbname":                   "somename123_db",
+		"root.db.connection.default.password":                 "aabbccddeeff",
+		"root.db.connection.default.active":                   "1",
+		"root.db.connection.default.driver_options.1014":      "FALSE",
+	}
+
+	parsed, err := Parse([]byte(src))
+	if err != nil {
+		t.Error("Parse failed:", err)
+	} else if !cmp.Equal(parsed, expected) {
+		t.Error("Parsed != expected:", cmp.Diff(expected, parsed))
+	}
+}
+
 func TestParseArray(t *testing.T) {
 	src := `
 <?php


### PR DESCRIPTION
## Summary
- The `unquote` function in `phpcfg` only handled single-quoted PHP strings, causing double-quoted values (e.g. `"localhost"`) to retain their surrounding quotes
- Fixed to strip both single and double quotes, with a length check to prevent panics on empty strings
- Added test case covering double-quoted Magento 2 env.php format

## Test plan
- [x] Existing tests pass
- [x] New `TestParseDoubleQuotedStrings` covers the reported scenario